### PR TITLE
Manage Http.HttpException return values

### DIFF
--- a/korio-ext-web/src/main/kotlin/com/soywiz/korio/ext/web/router/KorRouter.kt
+++ b/korio-ext-web/src/main/kotlin/com/soywiz/korio/ext/web/router/KorRouter.kt
@@ -289,6 +289,12 @@ suspend private fun registerHttpRoute(router: KorRouter, instance: Any, method: 
 						finalResult.write { buffer.append(it) }
 						res.end(buffer.toString())
 					}
+					is Http.HttpException -> {
+						// @TODO: add/replace headers
+						// @TODO: test this !
+						res.setStatus(finalResult.statusCode)
+						res.end(finalResult.statusText)
+					}
 					else -> {
 						res.replaceHeader("Content-Type", "application/json")
 						res.end(Json.encode(finalResult, mapper))


### PR DESCRIPTION
Consider an API call
/api/users/non-existent-username
where the route exists, but the resource requested is not found, or an operation is not allowed...

You should be abled to return (or throw) an exception. 
You should be abled to change the status code also (ie: 201 Created)

example:
```
@Route(Http.Methods.GET, "/api/v1/users/:username")
    suspend fun getUser(response: Http.Response, @Param("username") username: String): Any {

        response.header("Content-Type", "application/json; charset=utf-8")
        /* ...
            find the user by username
            ... */

        if(null == user){
            val jsonResponse = mapOf(
                    Pair("exception", "UserNotFoundException"),
                    Pair("message", "Could not get user"),
                    Pair("ressource", username)
            ).toJson()
            return Http.HttpException(404, "UserNotFoundException", jsonResponse)
        }

        return user
    }
```