### PR TITLE
fix parseInt and add default start/end parameter values.

### DIFF
--- a/korio/src/commonMain/kotlin/com/soywiz/korio/util/NumberParser.kt
+++ b/korio/src/commonMain/kotlin/com/soywiz/korio/util/NumberParser.kt
@@ -3,7 +3,7 @@ package com.soywiz.korio.util
 import kotlin.math.*
 
 object NumberParser {
-	fun parseInt(str: String, start: Int, end: Int, radix: Int = 10): Int {
+	fun parseInt(str: String, start: Int = 0, end: Int = str.length, radix: Int = 10): Int {
 		var positive = true
 		var out = 0
 		loop@ for (n in start until end) {
@@ -14,7 +14,7 @@ object NumberParser {
 				val value = c.ctypeAsInt()
 				if (value < 0) break@loop
 				out *= radix
-				out += c - 'a' + 10
+				out += value
 			}
 		}
 		return if (positive) out else -out

--- a/korio/src/commonTest/kotlin/com/soywiz/korio/util/NumberParserTest.kt
+++ b/korio/src/commonTest/kotlin/com/soywiz/korio/util/NumberParserTest.kt
@@ -14,6 +14,10 @@ class NumberParserTest {
 	@Test fun test6() = assertEquals(1e10, NumberParser.parseDouble("1e10"))
 	@Test fun test7() = assertEquals(1e-10, NumberParser.parseDouble("1e-10"), 0.0001)
 	@Test fun test8() = assertEquals(-1.5e-10, NumberParser.parseDouble("-1.5e-10"), 0.0001)
+    @Test fun test9() = assertEquals(123456, NumberParser.parseInt("123456"))
+    @Test fun test10() = assertEquals(-123456, NumberParser.parseInt("-123456"))
+    @Test fun test11() = assertEquals(123456, NumberParser.parseInt("1e240", radix = 16))
+    @Test fun test12() = assertEquals(-123456, NumberParser.parseInt("-1e240", radix = 16))
 
 	fun assertEquals(expected: Double, actual: Double, epsilon: Double) {
 		assertTrue("$expected != $actual (epsilon=$epsilon) (diff=${abs(expected - actual)})") { abs(expected - actual) <= epsilon }


### PR DESCRIPTION
Fixed a bug in the NumberParser.parseInt method.
And added a default start/end parameter.