### PR TITLE
Fix server closable

### DIFF
--- a/korio/build.gradle
+++ b/korio/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 	commonMainApi "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
-//	add("androidMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
+	add("androidMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
 	add("commonMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$coroutinesVersion")
 	add("jsMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$coroutinesVersion")
 	add("jvmMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")

--- a/korio/build.gradle
+++ b/korio/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 	commonMainApi "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
-	add("androidMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
+//	add("androidMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
 	add("commonMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-core-common:$coroutinesVersion")
 	add("jsMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$coroutinesVersion")
 	add("jvmMainApi", "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")

--- a/korio/src/commonMain/kotlin/com/soywiz/korio/net/AsyncSocketFactory.kt
+++ b/korio/src/commonMain/kotlin/com/soywiz/korio/net/AsyncSocketFactory.kt
@@ -47,7 +47,7 @@ interface AsyncClient : AsyncInputStream, AsyncOutputStream, AsyncCloseable {
 	}
 }
 
-interface AsyncServer {
+interface AsyncServer: AsyncCloseable {
 	val requestPort: Int
 	val host: String
 	val backlog: Int

--- a/korio/src/jvmMain/kotlin/com/soywiz/korio/net/asyncSocketFactoryJvm.kt
+++ b/korio/src/jvmMain/kotlin/com/soywiz/korio/net/asyncSocketFactoryJvm.kt
@@ -122,4 +122,8 @@ class JvmAsyncServer(override val requestPort: Int, override val host: String, o
 			}
 		})
 	}
+
+    override suspend fun close() {
+        ssc.close()
+    }
 }


### PR DESCRIPTION
The method _listen()_ in the interface _AsyncServer_ should return a Closeable, but because of the coroutine or launch, the Return is not reached. See below:

	suspend fun listen(handler: suspend (AsyncClient) -> Unit): Closeable {
		val job = coroutineScope {
			launchImmediately {
				while (true) {
					handler(accept())
				}
			}
		}
		return Closeable { job.cancel() }
	}

To fix that, we added to the Interface :AsyncClosable. 
And the class _JvmAsyncServer_ contains the method _close()_.