### PR TITLE
Remove indent for single text child in xml

### DIFF
--- a/korio/src/commonMain/kotlin/com/soywiz/korio/serialization/xml/Xml.kt
+++ b/korio/src/commonMain/kotlin/com/soywiz/korio/serialization/xml/Xml.kt
@@ -78,7 +78,11 @@ data class Xml(
 		when (type) {
 			Type.NODE -> {
 				if (allChildren.isEmpty()) {
-					line("<$name$attributesStr/>")
+                    line("<$name$attributesStr/>")
+                } else if (allChildren.size == 1 && allChildren[0].type == Type.TEXT) {
+                    inline("<$name$attributesStr>")
+                    inline(allChildren[0].content)
+                    line("</$name>")
 				} else {
 					line("<$name$attributesStr>")
 					indent {

--- a/korio/src/commonTest/kotlin/com/soywiz/korio/serialization/xml/XmlTest.kt
+++ b/korio/src/commonTest/kotlin/com/soywiz/korio/serialization/xml/XmlTest.kt
@@ -56,4 +56,26 @@ class XmlTest {
 		)
 	}
 
+    @Test
+    fun testIndent() {
+        val xml1 = buildXml("name") {
+            text("SimpleName")
+        }
+        assertEquals("<name>SimpleName</name>\n", xml1.toOuterXmlIndented().toString())
+
+        val xml2 = buildXml("name") {
+            text("SimpleName")
+            text("ComplicatedName")
+        }
+        assertEquals("<name>\n\tSimpleName\n\tComplicatedName\n</name>\n", xml2.toOuterXmlIndented().toString())
+
+        val xml3 = buildXml("name", "number" to 1) {
+            comment("Some comment")
+            node("value", "number" to 2) {
+                text("SimpleName")
+            }
+        }
+        val result2 = "<name number=\"1\">\n\t<!--Some comment-->\n\t<value number=\"2\">SimpleName</value>\n</name>\n"
+        assertEquals(result2, xml3.toOuterXmlIndented().toString())
+    }
 }


### PR DESCRIPTION
Remove indent if a node's child is a single text element.

Old implementation:
```
<node>
    Some text
</node>
```
Fixed implementation:
```
<node>Some text</node>
```

It's also useful for a multiline text element when you need to specify custom indent for text (or no indent at all).

Old implementation for "0, 0, 0, 0,\n0, 0, 0, 0,\n0, 0, 0, 0\n":
```
<node>
    0, 0, 0, 0,
0, 0, 0, 0,
0, 0, 0, 0
</node>
```
Fixed implementation for "\n0, 0, 0, 0,\n0, 0, 0, 0,\n0, 0, 0, 0\n":
```
<node>
0, 0, 0, 0,
0, 0, 0, 0,
0, 0, 0, 0
</node>
```